### PR TITLE
Add onchain withdrawal functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,20 @@ class Cashramp {
     return this.sendRequest({ name: "account", query: ACCOUNT });
   }
 
+  /**
+   * Fetch the onchain withdrawal information for the authenticated user.
+   * @param {object} options
+   * @param {string} options.id The onchain withdrawal's global ID
+   * @returns {CashrampResponse} response.result { quantity: string, symbol: string, network: string, address: string, txhash: string, txhashUrl: string, fee: string, status: string, createdAt: string }
+   */
+  async getOnchainWithdrawal({ withdrawalId }) {
+    return this.sendRequest({
+      name: "onchainWithdrawal",
+      query: ONCHAIN_WITHDRAWAL,
+      variables: { id },
+    });
+  }
+
   // MUTATIONS
 
   /**

--- a/src/queries.js
+++ b/src/queries.js
@@ -97,6 +97,22 @@ const REFRESH_RAMP_QUOTE = `
   }
 `;
 
+const ONCHAIN_WITHDRAWAL = `
+  query ($withdrawalId: ID!) {
+    onchainWithdrawal(id: $withdrawalId) {
+      quantity
+      symbol
+      network
+      address
+      txhash
+      txhashUrl
+      fee
+      status
+      createdAt
+    }
+  }
+`
+
 module.exports = {
   AVAILABLE_COUNTRIES,
   MARKET_RATE,
@@ -107,4 +123,5 @@ module.exports = {
   ACCOUNT,
   RAMP_QUOTE,
   REFRESH_RAMP_QUOTE,
+  ONCHAIN_WITHDRAWAL,
 };

--- a/tests/queries.spec.js
+++ b/tests/queries.spec.js
@@ -220,4 +220,28 @@ describe("Cashramp queries", () => {
     const mockCallIndex = fetch.mock.calls.length - 1;
     expect(fetch.mock.calls[mockCallIndex][1].body).toContain(name);
   });
+
+  test("it should get an onchain withdrawal", async () => {
+    const name = "onchainWithdrawal";
+    const result = {
+      quantity: "100",
+      symbol: "USDT",
+      network: "OP",
+      address: "0x17A08127364A7C897e557611176A73Eef5642C81",
+      txhash: "0x17A08127364A7C897e557611176A73Eef5642C81",
+      txhashUrl: "https://opscan.io/tx/0x17A08127364A7C897e557611176A73Eef5642C81",
+      fee: "1",
+      status: "completed",
+      createdAt: "2021-01-01T00:00:00Z",
+    };
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result }));
+
+    const response = await client.getOnchainWithdrawal({ withdrawalId: "1" });
+
+    expect(response.success).toBeTruthy();
+    expect(response.result).toBe(result);
+
+    const mockCallIndex = fetch.mock.calls.length - 1;
+    expect(fetch.mock.calls[mockCallIndex][1].body).toContain(name);
+  });
 });


### PR DESCRIPTION
- Implemented `getOnchainWithdrawal` method in the Cashramp class to fetch onchain withdrawal details for authenticated users.
- Added GraphQL query for onchain withdrawals.