### PR TITLE
feat: add Bot Agent API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The official NodeJS SDK for [Cashramp's API](https://cashramp.co/commerce).
   - [Hosted Payments](#hosted-payments)
   - [Direct Ramp - Deposits](#direct-ramp---deposits)
   - [Direct Ramp - Withdrawals](#direct-ramp---withdrawals)
+  - [Bot Agents](#bot-agents)
 - [API Reference](#api-reference)
   - [Queries](#queries)
   - [Mutations](#mutations)
@@ -180,6 +181,50 @@ await cashramp.markWithdrawalAsReceived({
 });
 ```
 
+### Bot Agents
+
+If your secret key is bound to an Agent (not a merchant), the SDK can drive a bot agent end-to-end against Cashramp's bot agent GraphQL surface. Bot agent methods automatically target `/cashramp/bot/graphql` (the merchant endpoint at `/cashramp/api/graphql` is unaffected). The same `secretKey` constructor argument is used.
+
+```js
+const cashramp = new Cashramp({
+  env: "test",
+  secretKey: "CSHRMP-SECK_your_agent_secret_key", // an APIKey whose bearer is an Agent
+});
+
+// 1. Inspect the agent profile
+const profile = await cashramp.getBotAgentProfile();
+
+// 2. Set deposit/withdrawal rates and margins
+await cashramp.updateBotAgentRates({
+  depositRate: 1500,
+  withdrawalRate: 1490,
+  depositMargin: 0.005,
+});
+
+// 3. Top up local-currency liquidity for one of your payment methods
+await cashramp.updateBotAgentPaymentMethodLiquidity({
+  paymentMethod: "pm_global_id",
+  amountLocal: 5_000_000,
+});
+
+// 4. Page through assigned orders
+const orders = await cashramp.getBotAgentOrderHistory({
+  page: 1,
+  perPage: 20,
+  filter: { status: "pending" },
+});
+
+// 5. Accept an assigned withdrawal, then mark it paid after sending fiat
+const assignment = orders.result.data[0];
+await cashramp.acceptBotAgentWithdrawal({ paymentRequest: assignment.id });
+
+await cashramp.markBotAgentWithdrawalPaid({
+  paymentRequest: assignment.id,
+  paymentMethod: "pm_global_id",
+  receipt: "https://example.com/receipt.png",
+});
+```
+
 ## API Reference
 
 ### Queries
@@ -244,6 +289,22 @@ await cashramp.markWithdrawalAsReceived({
 | --------------------------------------------------------- | --------------------------------- |
 | `confirmTransaction({ paymentRequest, transactionHash })` | Confirm crypto transfer to escrow |
 | `withdrawOnchain({ address, amountUsd })`                 | Withdraw from balance to wallet   |
+
+#### Bot Agents
+
+All bot agent methods target `/cashramp/bot/graphql` and require a `secretKey` whose bearer APIKey is an Agent record. `paymentRequest` accepts a P2P payment global ID and is mapped to the GraphQL `p2pPayment` argument internally.
+
+| Method                                                                                              | Returns                          | Description                                                                |
+| --------------------------------------------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------- |
+| `getBotAgentProfile()`                                                                              | `BotAgentProfile`                | Authenticated agent profile (id, balances, rates, margins, counts, ...)    |
+| `getBotAgentOrderHistory({ page, perPage?, filter? })`                                              | `{ data, pagination }`           | Page/perPage paginated P2P payments. Filter: `orderId/status/dateFrom/dateTo/paymentMethod` |
+| `getBotAgentWithdrawalInfo({ symbol })`                                                             | `WithdrawalInfo`                 | Onchain destination/network info for a crypto symbol                       |
+| `acceptBotAgentWithdrawal({ paymentRequest })`                                                      | `boolean`                        | Accept an assigned withdrawal request                                      |
+| `cancelBotAgentWithdrawal({ paymentRequest })`                                                      | `boolean`                        | Cancel/decline an assigned withdrawal request                              |
+| `markBotAgentDepositReceived({ paymentRequest })`                                                   | `boolean`                        | Acknowledge receipt of customer fiat for a deposit leg                     |
+| `markBotAgentWithdrawalPaid({ paymentRequest, paymentMethod, receipt? })`                           | `boolean`                        | Acknowledge sending fiat for a withdrawal leg (`paymentMethod` required)   |
+| `updateBotAgentRates({ depositRate?, depositMargin?, withdrawalRate?, withdrawalMargin? })`         | `boolean`                        | Set agent rates/margins (only provided keys are sent)                      |
+| `updateBotAgentPaymentMethodLiquidity({ amountLocal, paymentMethod?, paymentMethodType? })`         | `P2PPaymentMethod`               | Set local-currency liquidity for a payment method                          |
 
 #### onchainTransferInfo Object
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cashramp",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "description": "Cashramp API NodeJS SDK",
   "main": "src/index.js",
   "files": [

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -269,6 +269,144 @@ declare module 'cashramp' {
     query: string;
     /** (Optional) Variables for the GraphQL query */
     variables?: Record<string, any>;
+    /** (Optional) Which Cashramp schema to target. Defaults to "merchant". */
+    endpoint?: 'merchant' | 'bot';
+  }
+
+  /** Pagination metadata returned by paginated bot agent endpoints */
+  export interface BotAgentPagination {
+    page: number;
+    perPage: number;
+    total: number;
+  }
+
+  /** A bot agent profile (operationally useful subset of CashrampAgentProfile) */
+  export interface BotAgentProfile {
+    id: string;
+    email: string;
+    accountBalance: string;
+    escrowBalance: string;
+    bonusEarnings: string;
+    depositAddress: string;
+    verificationStatus: string;
+    autoUpdateDepositRate: boolean;
+    autoUpdateWithdrawalRate: boolean;
+    creditLine: string;
+    usedCreditLine: string;
+    depositMargin: string;
+    withdrawalMargin: string;
+    averageDepositRate: string;
+    averageWithdrawalRate: string;
+    depositsCompleted: number;
+    withdrawalsCompleted: number;
+    totalDepositFiatAmount: string;
+    totalDepositUsdAmount: string;
+    totalWithdrawalFiatAmount: string;
+    totalWithdrawalUsdAmount: string;
+    enforceReceiptUpload: boolean;
+    apiKey: string;
+  }
+
+  /** A P2P payment row from the bot agent order history */
+  export interface BotAgentP2PPayment {
+    id: string;
+    status: string;
+    paymentType: PaymentType;
+    exchangeRate: string;
+    exchangeRateMinusSurcharge: string;
+    orderId: string;
+    source: string;
+    instant: boolean;
+    createdAt: string;
+    expiresAt: string;
+    expiresAtSecs: number;
+    reassigning: boolean;
+    reassignAfter: string;
+    reassignAfterSecs: number;
+    agentCutOfFees: string;
+    fxSpreadRevenue: string;
+  }
+
+  /** Order history filter passed to getBotAgentOrderHistory */
+  export interface BotAgentOrderHistoryFilter {
+    orderId?: string;
+    status?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    paymentMethod?: string;
+  }
+
+  /** Options for getBotAgentOrderHistory */
+  export interface GetBotAgentOrderHistoryOptions {
+    page: number;
+    perPage?: number;
+    filter?: BotAgentOrderHistoryFilter;
+  }
+
+  /** Paginated bot agent order history result */
+  export interface BotAgentOrderHistory {
+    data: BotAgentP2PPayment[];
+    pagination: BotAgentPagination;
+  }
+
+  /** Options for getBotAgentWithdrawalInfo */
+  export interface GetBotAgentWithdrawalInfoOptions {
+    /** The crypto symbol (e.g. "USDC") */
+    symbol: string;
+  }
+
+  /** Withdrawal info returned for a crypto symbol */
+  export interface BotAgentWithdrawalInfo {
+    symbol: string;
+    networks: string[];
+    addressRegex?: string;
+    memoRegex?: string;
+  }
+
+  /** Options for accept/cancel bot agent withdrawal and mark deposit received */
+  export interface BotAgentP2PPaymentOptions {
+    /** The P2P payment's global ID */
+    paymentRequest: string;
+  }
+
+  /** Options for markBotAgentWithdrawalPaid */
+  export interface MarkBotAgentWithdrawalPaidOptions {
+    /** The P2P payment's global ID */
+    paymentRequest: string;
+    /** The payment method's global ID the agent paid from */
+    paymentMethod: string;
+    /** Optional receipt string */
+    receipt?: string;
+  }
+
+  /** Options for updateBotAgentRates. All fields optional; only provided keys are sent. */
+  export interface UpdateBotAgentRatesOptions {
+    depositRate?: number | string;
+    depositMargin?: number | string;
+    withdrawalRate?: number | string;
+    withdrawalMargin?: number | string;
+  }
+
+  /** Options for updateBotAgentPaymentMethodLiquidity */
+  export interface UpdateBotAgentPaymentMethodLiquidityOptions {
+    /** Required local-currency amount */
+    amountLocal: number | string;
+    /** Optional existing payment method global ID */
+    paymentMethod?: string;
+    /** Optional payment method type identifier */
+    paymentMethodType?: string;
+  }
+
+  /** A P2P payment method as returned by the bot agent liquidity mutation */
+  export interface BotAgentP2PPaymentMethod {
+    id: string;
+    value: string;
+    displayValue: string;
+    localCurrencyAvailable: string;
+    deleted: boolean;
+    ownership: string;
+    designation: string;
+    instant: boolean;
   }
 
   export class Cashramp {
@@ -413,6 +551,62 @@ declare module 'cashramp' {
      * @returns Promise resolving to CashrampResponse (result type might need clarification from API)
      */
     withdrawOnchain(options: WithdrawOnchainOptions): Promise<CashrampResponse>;
+
+    /**
+     * Fetch the authenticated bot agent's profile
+     * @returns Promise resolving to CashrampResponse with BotAgentProfile
+     */
+    getBotAgentProfile(): Promise<CashrampResponse<BotAgentProfile>>;
+
+    /**
+     * Fetch the bot agent's order history (page/perPage pagination)
+     * @param options Page, perPage, and optional filter
+     * @returns Promise resolving to CashrampResponse with BotAgentOrderHistory
+     */
+    getBotAgentOrderHistory(options: GetBotAgentOrderHistoryOptions): Promise<CashrampResponse<BotAgentOrderHistory>>;
+
+    /**
+     * Fetch withdrawal info for a crypto symbol (used by bot agents before paying out onchain)
+     * @param options Crypto symbol
+     * @returns Promise resolving to CashrampResponse with BotAgentWithdrawalInfo
+     */
+    getBotAgentWithdrawalInfo(options: GetBotAgentWithdrawalInfoOptions): Promise<CashrampResponse<BotAgentWithdrawalInfo>>;
+
+    /**
+     * Accept an assigned withdrawal request as a bot agent
+     * @param options P2P payment global ID
+     */
+    acceptBotAgentWithdrawal(options: BotAgentP2PPaymentOptions): Promise<CashrampResponse<boolean>>;
+
+    /**
+     * Cancel/decline an assigned withdrawal request as a bot agent
+     * @param options P2P payment global ID
+     */
+    cancelBotAgentWithdrawal(options: BotAgentP2PPaymentOptions): Promise<CashrampResponse<boolean>>;
+
+    /**
+     * Acknowledge receipt of customer fiat for a deposit leg as a bot agent
+     * @param options P2P payment global ID
+     */
+    markBotAgentDepositReceived(options: BotAgentP2PPaymentOptions): Promise<CashrampResponse<boolean>>;
+
+    /**
+     * Acknowledge sending fiat for a withdrawal leg as a bot agent
+     * @param options P2P payment global ID, paying payment method, and optional receipt
+     */
+    markBotAgentWithdrawalPaid(options: MarkBotAgentWithdrawalPaidOptions): Promise<CashrampResponse<boolean>>;
+
+    /**
+     * Update bot agent rates and margins (only provided fields are sent)
+     * @param options Optional rate/margin fields
+     */
+    updateBotAgentRates(options?: UpdateBotAgentRatesOptions): Promise<CashrampResponse<boolean>>;
+
+    /**
+     * Set the local-currency liquidity available for a bot agent payment method
+     * @param options Local currency amount and identifier (paymentMethod or paymentMethodType)
+     */
+    updateBotAgentPaymentMethodLiquidity(options: UpdateBotAgentPaymentMethodLiquidityOptions): Promise<CashrampResponse<BotAgentP2PPaymentMethod>>;
 
     /**
      * Query the Cashramp API directly

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,9 @@ const {
   RAMP_QUOTE,
   ACCOUNT,
   REFRESH_RAMP_QUOTE,
+  BOT_AGENT_PROFILE,
+  BOT_AGENT_ORDER_HISTORY,
+  BOT_AGENT_WITHDRAWAL_INFO,
 } = require("./queries");
 const {
   CONFIRM_TRANSACTION,
@@ -30,6 +33,12 @@ const {
   MARK_WITHDRAWAL_AS_RECEIVED,
   MARK_DEPOSIT_AS_PAID,
   CANCEL_DEPOSIT,
+  BOT_AGENT_ACCEPT_WITHDRAWAL,
+  BOT_AGENT_CANCEL_WITHDRAWAL,
+  BOT_AGENT_MARK_DEPOSIT_AS_RECEIVED,
+  BOT_AGENT_MARK_WITHDRAWAL_AS_PAID,
+  BOT_AGENT_UPDATE_RATES,
+  BOT_AGENT_UPDATE_PAYMENT_METHOD_LIQUIDITY,
 } = require("./mutations");
 
 class Cashramp {
@@ -407,6 +416,158 @@ class Cashramp {
     });
   }
 
+  // ---------- BOT AGENT ----------
+
+  /**
+   * Fetch the authenticated bot agent's profile
+   * @returns {CashrampResponse} response.result The agent profile
+   */
+  async getBotAgentProfile() {
+    return this.sendRequest({
+      name: "profile",
+      query: BOT_AGENT_PROFILE,
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Fetch the bot agent's order history
+   * @param {object} options
+   * @param {number} options.page The 1-indexed page number
+   * @param {number} options.perPage Optional results per page (default 10)
+   * @param {object} options.filter Optional filter ({ orderId, status, dateFrom, dateTo, paymentMethod })
+   * @returns {CashrampResponse} response.result { data: [P2PPayment], pagination: { page, perPage, total } }
+   */
+  async getBotAgentOrderHistory({ page, perPage, filter } = {}) {
+    return this.sendRequest({
+      name: "orderHistory",
+      query: BOT_AGENT_ORDER_HISTORY,
+      variables: { page, perPage, filter },
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Fetch withdrawal info (networks, address regex, etc.) for a crypto symbol
+   * @param {object} options
+   * @param {string} options.symbol The crypto symbol (e.g. "USDC")
+   * @returns {CashrampResponse}
+   */
+  async getBotAgentWithdrawalInfo({ symbol }) {
+    return this.sendRequest({
+      name: "withdrawalInfo",
+      query: BOT_AGENT_WITHDRAWAL_INFO,
+      variables: { symbol },
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Accept an assigned withdrawal request as a bot agent
+   * @param {object} options
+   * @param {string} options.paymentRequest The P2P payment's global ID
+   * @returns {CashrampResponse}
+   */
+  async acceptBotAgentWithdrawal({ paymentRequest }) {
+    return this.sendRequest({
+      name: "acceptWithdrawal",
+      query: BOT_AGENT_ACCEPT_WITHDRAWAL,
+      variables: { p2pPayment: paymentRequest },
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Cancel/decline an assigned withdrawal request as a bot agent
+   * @param {object} options
+   * @param {string} options.paymentRequest The P2P payment's global ID
+   * @returns {CashrampResponse}
+   */
+  async cancelBotAgentWithdrawal({ paymentRequest }) {
+    return this.sendRequest({
+      name: "cancelWithdrawal",
+      query: BOT_AGENT_CANCEL_WITHDRAWAL,
+      variables: { p2pPayment: paymentRequest },
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Acknowledge receipt of customer fiat for a deposit leg as a bot agent
+   * @param {object} options
+   * @param {string} options.paymentRequest The P2P payment's global ID
+   * @returns {CashrampResponse}
+   */
+  async markBotAgentDepositReceived({ paymentRequest }) {
+    return this.sendRequest({
+      name: "markDepositAsReceived",
+      query: BOT_AGENT_MARK_DEPOSIT_AS_RECEIVED,
+      variables: { p2pPayment: paymentRequest },
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Acknowledge sending fiat for a withdrawal leg as a bot agent
+   * @param {object} options
+   * @param {string} options.paymentRequest The P2P payment's global ID
+   * @param {string} options.paymentMethod The payment method's global ID the agent paid from
+   * @param {string} options.receipt Optional receipt string
+   * @returns {CashrampResponse}
+   */
+  async markBotAgentWithdrawalPaid({ paymentRequest, paymentMethod, receipt }) {
+    return this.sendRequest({
+      name: "markWithdrawalAsPaid",
+      query: BOT_AGENT_MARK_WITHDRAWAL_AS_PAID,
+      variables: { p2pPayment: paymentRequest, paymentMethod, receipt },
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Update bot agent rates and margins. Only provided fields are sent.
+   * @param {object} options
+   * @param {number|string} options.depositRate Optional deposit rate
+   * @param {number|string} options.depositMargin Optional deposit margin
+   * @param {number|string} options.withdrawalRate Optional withdrawal rate
+   * @param {number|string} options.withdrawalMargin Optional withdrawal margin
+   * @returns {CashrampResponse}
+   */
+  async updateBotAgentRates({
+    depositRate,
+    depositMargin,
+    withdrawalRate,
+    withdrawalMargin,
+  } = {}) {
+    return this.sendRequest({
+      name: "updateRates",
+      query: BOT_AGENT_UPDATE_RATES,
+      variables: { depositRate, depositMargin, withdrawalRate, withdrawalMargin },
+      endpoint: "bot",
+    });
+  }
+
+  /**
+   * Set the local-currency liquidity available for a bot agent payment method
+   * @param {object} options
+   * @param {number|string} options.amountLocal Required local currency amount
+   * @param {string} options.paymentMethod Optional existing payment method global ID
+   * @param {string} options.paymentMethodType Optional payment method type identifier
+   * @returns {CashrampResponse} response.result The updated P2P payment method
+   */
+  async updateBotAgentPaymentMethodLiquidity({
+    amountLocal,
+    paymentMethod,
+    paymentMethodType,
+  }) {
+    return this.sendRequest({
+      name: "updatePaymentMethodLiquidity",
+      query: BOT_AGENT_UPDATE_PAYMENT_METHOD_LIQUIDITY,
+      variables: { amountLocal, paymentMethod, paymentMethodType },
+      endpoint: "bot",
+    });
+  }
+
   // GENERAL
   /**
    * Query the Cashramp API directly
@@ -414,11 +575,13 @@ class Cashramp {
    * @param {string} options.name The name of the query/mutation
    * @param {string} options.query The GraphQL query string
    * @param {object} options.variables (Optional) Pass in variables for the GraphQL query
+   * @param {"merchant"|"bot"} options.endpoint (Optional) Which Cashramp schema to target. Defaults to "merchant".
    * @returns {CashrampResponse}
    */
-  async sendRequest({ name, query, variables }) {
+  async sendRequest({ name, query, variables, endpoint }) {
+    const url = endpoint === "bot" ? this._botApiURL : this._apiURL;
     try {
-      const response = await fetch(this._apiURL, {
+      const response = await fetch(url, {
         method: "post",
         body: JSON.stringify({
           query,
@@ -452,6 +615,7 @@ class Cashramp {
     let host = "api.useaccrue.com";
     if (this._env == "test") host = `staging.${host}`;
     this._apiURL = `https://${host}/cashramp/api/graphql`;
+    this._botApiURL = `https://${host}/cashramp/bot/graphql`;
   }
 }
 

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -105,6 +105,53 @@ const CANCEL_DEPOSIT = `
   }
 `;
 
+// ---------- Bot Agent ----------
+
+const BOT_AGENT_ACCEPT_WITHDRAWAL = `
+  mutation ($p2pPayment: ID!) {
+    acceptWithdrawal(p2pPayment: $p2pPayment)
+  }
+`;
+
+const BOT_AGENT_CANCEL_WITHDRAWAL = `
+  mutation ($p2pPayment: ID!) {
+    cancelWithdrawal(p2pPayment: $p2pPayment)
+  }
+`;
+
+const BOT_AGENT_MARK_DEPOSIT_AS_RECEIVED = `
+  mutation ($p2pPayment: ID!) {
+    markDepositAsReceived(p2pPayment: $p2pPayment)
+  }
+`;
+
+const BOT_AGENT_MARK_WITHDRAWAL_AS_PAID = `
+  mutation ($p2pPayment: ID!, $paymentMethod: ID!, $receipt: String) {
+    markWithdrawalAsPaid(p2pPayment: $p2pPayment, paymentMethod: $paymentMethod, receipt: $receipt)
+  }
+`;
+
+const BOT_AGENT_UPDATE_RATES = `
+  mutation ($depositRate: Decimal, $depositMargin: Decimal, $withdrawalRate: Decimal, $withdrawalMargin: Decimal) {
+    updateRates(depositRate: $depositRate, depositMargin: $depositMargin, withdrawalRate: $withdrawalRate, withdrawalMargin: $withdrawalMargin)
+  }
+`;
+
+const BOT_AGENT_UPDATE_PAYMENT_METHOD_LIQUIDITY = `
+  mutation ($paymentMethod: ID, $paymentMethodType: String, $amountLocal: Decimal!) {
+    updatePaymentMethodLiquidity(paymentMethod: $paymentMethod, paymentMethodType: $paymentMethodType, amountLocal: $amountLocal) {
+      id
+      value
+      displayValue
+      localCurrencyAvailable
+      deleted
+      ownership
+      designation
+      instant
+    }
+  }
+`;
+
 module.exports = {
   CONFIRM_TRANSACTION,
   INITIATE_HOSTED_PAYMENT,
@@ -117,4 +164,10 @@ module.exports = {
   MARK_DEPOSIT_AS_PAID,
   MARK_WITHDRAWAL_AS_RECEIVED,
   CANCEL_DEPOSIT,
+  BOT_AGENT_ACCEPT_WITHDRAWAL,
+  BOT_AGENT_CANCEL_WITHDRAWAL,
+  BOT_AGENT_MARK_DEPOSIT_AS_RECEIVED,
+  BOT_AGENT_MARK_WITHDRAWAL_AS_PAID,
+  BOT_AGENT_UPDATE_RATES,
+  BOT_AGENT_UPDATE_PAYMENT_METHOD_LIQUIDITY,
 };

--- a/src/queries.js
+++ b/src/queries.js
@@ -99,6 +99,79 @@ const REFRESH_RAMP_QUOTE = `
   }
 `;
 
+// ---------- Bot Agent ----------
+
+const BOT_AGENT_PROFILE = `
+  query {
+    profile {
+      id
+      email
+      accountBalance
+      escrowBalance
+      bonusEarnings
+      depositAddress
+      verificationStatus
+      autoUpdateDepositRate
+      autoUpdateWithdrawalRate
+      creditLine
+      usedCreditLine
+      depositMargin
+      withdrawalMargin
+      averageDepositRate
+      averageWithdrawalRate
+      depositsCompleted
+      withdrawalsCompleted
+      totalDepositFiatAmount
+      totalDepositUsdAmount
+      totalWithdrawalFiatAmount
+      totalWithdrawalUsdAmount
+      enforceReceiptUpload
+      apiKey
+    }
+  }
+`;
+
+const BOT_AGENT_ORDER_HISTORY = `
+  query ($filter: OrderHistoryFilter, $page: Int!, $perPage: Int) {
+    orderHistory(filter: $filter, page: $page, perPage: $perPage) {
+      data {
+        id
+        status
+        paymentType
+        exchangeRate
+        exchangeRateMinusSurcharge
+        orderId
+        source
+        instant
+        createdAt
+        expiresAt
+        expiresAtSecs
+        reassigning
+        reassignAfter
+        reassignAfterSecs
+        agentCutOfFees
+        fxSpreadRevenue
+      }
+      pagination {
+        page
+        perPage
+        total
+      }
+    }
+  }
+`;
+
+const BOT_AGENT_WITHDRAWAL_INFO = `
+  query ($symbol: String!) {
+    withdrawalInfo(symbol: $symbol) {
+      symbol
+      networks
+      addressRegex
+      memoRegex
+    }
+  }
+`;
+
 module.exports = {
   AVAILABLE_COUNTRIES,
   MARKET_RATE,
@@ -109,4 +182,7 @@ module.exports = {
   ACCOUNT,
   RAMP_QUOTE,
   REFRESH_RAMP_QUOTE,
+  BOT_AGENT_PROFILE,
+  BOT_AGENT_ORDER_HISTORY,
+  BOT_AGENT_WITHDRAWAL_INFO,
 };

--- a/tests/bot-agent.spec.js
+++ b/tests/bot-agent.spec.js
@@ -1,0 +1,188 @@
+jest.mock("node-fetch");
+
+const Cashramp = require("../src/index");
+const { createGraphQLJSONResponse } = require("./index");
+
+const BOT_ENDPOINT = "https://staging.api.useaccrue.com/cashramp/bot/graphql";
+const MERCHANT_ENDPOINT =
+  "https://staging.api.useaccrue.com/cashramp/api/graphql";
+
+describe("Cashramp bot agent surface", () => {
+  let client = null;
+  let fetch = null;
+  const secretKey = "CSHRMP-SECK-123456789";
+
+  beforeEach(() => {
+    client = new Cashramp({ secretKey, env: "test" });
+    fetch = require("node-fetch");
+  });
+
+  test("it exposes both the merchant and bot endpoint URLs", () => {
+    expect(client._apiURL).toBe(MERCHANT_ENDPOINT);
+    expect(client._botApiURL).toBe(BOT_ENDPOINT);
+  });
+
+  test("getBotAgentProfile hits the bot endpoint and returns the profile", async () => {
+    const name = "profile";
+    const result = {
+      id: "agent_1",
+      email: "agent@useaccrue.com",
+      accountBalance: "100.00",
+    };
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result }));
+
+    const response = await client.getBotAgentProfile();
+    expect(response.success).toBeTruthy();
+    expect(response.result).toBe(result);
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    expect(init.body).toContain(name);
+  });
+
+  test("getBotAgentOrderHistory forwards page/perPage/filter and uses bot endpoint", async () => {
+    const name = "orderHistory";
+    const result = { data: [], pagination: { page: 1, perPage: 10, total: 0 } };
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result }));
+
+    const response = await client.getBotAgentOrderHistory({
+      page: 2,
+      perPage: 20,
+      filter: { status: "completed" },
+    });
+    expect(response.success).toBeTruthy();
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    const body = JSON.parse(init.body);
+    expect(body.variables).toEqual({
+      page: 2,
+      perPage: 20,
+      filter: { status: "completed" },
+    });
+  });
+
+  test("getBotAgentWithdrawalInfo forwards symbol and uses bot endpoint", async () => {
+    const name = "withdrawalInfo";
+    const result = { symbol: "USDC", networks: ["celo"] };
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result }));
+
+    const response = await client.getBotAgentWithdrawalInfo({ symbol: "USDC" });
+    expect(response.success).toBeTruthy();
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    expect(JSON.parse(init.body).variables).toEqual({ symbol: "USDC" });
+  });
+
+  test("acceptBotAgentWithdrawal maps paymentRequest -> p2pPayment and hits bot endpoint", async () => {
+    const name = "acceptWithdrawal";
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result: true }));
+
+    const response = await client.acceptBotAgentWithdrawal({
+      paymentRequest: "p2p_1",
+    });
+    expect(response.success).toBeTruthy();
+    expect(response.result).toBe(true);
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    const body = JSON.parse(init.body);
+    expect(body.variables).toEqual({ p2pPayment: "p2p_1" });
+    expect(body.query).toContain("acceptWithdrawal");
+  });
+
+  test("cancelBotAgentWithdrawal maps paymentRequest -> p2pPayment and hits bot endpoint", async () => {
+    const name = "cancelWithdrawal";
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result: true }));
+
+    const response = await client.cancelBotAgentWithdrawal({
+      paymentRequest: "p2p_1",
+    });
+    expect(response.success).toBeTruthy();
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    expect(JSON.parse(init.body).variables).toEqual({ p2pPayment: "p2p_1" });
+  });
+
+  test("markBotAgentDepositReceived maps paymentRequest -> p2pPayment and hits bot endpoint", async () => {
+    const name = "markDepositAsReceived";
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result: true }));
+
+    const response = await client.markBotAgentDepositReceived({
+      paymentRequest: "p2p_1",
+    });
+    expect(response.success).toBeTruthy();
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    expect(JSON.parse(init.body).variables).toEqual({ p2pPayment: "p2p_1" });
+  });
+
+  test("markBotAgentWithdrawalPaid forwards p2pPayment, paymentMethod, optional receipt", async () => {
+    const name = "markWithdrawalAsPaid";
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result: true }));
+
+    const response = await client.markBotAgentWithdrawalPaid({
+      paymentRequest: "p2p_1",
+      paymentMethod: "pm_1",
+      receipt: "https://example.com/receipt.png",
+    });
+    expect(response.success).toBeTruthy();
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    expect(JSON.parse(init.body).variables).toEqual({
+      p2pPayment: "p2p_1",
+      paymentMethod: "pm_1",
+      receipt: "https://example.com/receipt.png",
+    });
+  });
+
+  test("updateBotAgentRates forwards only provided fields and hits bot endpoint", async () => {
+    const name = "updateRates";
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result: true }));
+
+    const response = await client.updateBotAgentRates({
+      depositRate: 1500,
+      withdrawalMargin: "0.01",
+    });
+    expect(response.success).toBeTruthy();
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    const variables = JSON.parse(init.body).variables;
+    expect(variables.depositRate).toBe(1500);
+    expect(variables.withdrawalMargin).toBe("0.01");
+  });
+
+  test("updateBotAgentPaymentMethodLiquidity sends amountLocal + paymentMethod and hits bot endpoint", async () => {
+    const name = "updatePaymentMethodLiquidity";
+    const result = { id: "pm_1", localCurrencyAvailable: "5000" };
+    fetch.mockReturnValue(createGraphQLJSONResponse({ name, result }));
+
+    const response = await client.updateBotAgentPaymentMethodLiquidity({
+      amountLocal: 5000,
+      paymentMethod: "pm_1",
+    });
+    expect(response.success).toBeTruthy();
+    expect(response.result).toBe(result);
+
+    const [url, init] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(BOT_ENDPOINT);
+    expect(JSON.parse(init.body).variables).toEqual({
+      amountLocal: 5000,
+      paymentMethod: "pm_1",
+    });
+  });
+
+  test("merchant methods continue to hit the merchant endpoint", async () => {
+    fetch.mockReturnValue(
+      createGraphQLJSONResponse({ name: "availableCountries", result: [] })
+    );
+    await client.getAvailableCountries();
+    const [url] = fetch.mock.calls[fetch.mock.calls.length - 1];
+    expect(url).toBe(MERCHANT_ENDPOINT);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-class Bot Agent surface to the Node SDK, mirroring `CashrampBotSchema` (mounted at `POST /cashramp/bot/graphql`). Partners running bot agents can now drive the bot lifecycle end-to-end without hand-rolling GraphQL.

The merchant surface at `/cashramp/api/graphql` is unchanged — bot routing is opt-in via a new `endpoint` flag on `sendRequest`. Same `secretKey` constructor argument is reused; the API decides routing based on the bearer APIKey type.

### New methods on the `Cashramp` class

- `getBotAgentProfile()`
- `getBotAgentOrderHistory({ page, perPage?, filter? })` — page/perPage pagination (NOT Relay)
- `getBotAgentWithdrawalInfo({ symbol })`
- `acceptBotAgentWithdrawal({ paymentRequest })`
- `cancelBotAgentWithdrawal({ paymentRequest })`
- `markBotAgentDepositReceived({ paymentRequest })`
- `markBotAgentWithdrawalPaid({ paymentRequest, paymentMethod, receipt? })`
- `updateBotAgentRates({ depositRate?, depositMargin?, withdrawalRate?, withdrawalMargin? })` — only provided keys are sent
- `updateBotAgentPaymentMethodLiquidity({ amountLocal, paymentMethod?, paymentMethodType? })`

`paymentRequest` (P2P payment global ID) is mapped internally to the GraphQL `p2pPayment` argument so the public surface stays consistent with the merchant SDK.

### Other changes

- `sendRequest` accepts `endpoint: "merchant" | "bot"` (default merchant).
- New bot endpoint URL added in `_setup` (`/cashramp/bot/graphql`).
- New GraphQL operation strings in `src/queries.js` and `src/mutations.js`.
- TypeScript declarations added in `src/index.d.ts`.
- README gains a Bot Agents section + API reference rows.
- Version bump 0.0.13 → 0.1.0.

### Cross-repo parity

- cashramp-sdk-ruby companion PR: see https://github.com/rockets-hq/cashramp-sdk-ruby/pull/new/feat/bot-agent-api
- cashramp-sdk-go: not present locally, follow-up.

## Test plan

- [x] `yarn test` — 42/42 passing (4 suites, includes new `tests/bot-agent.spec.js` with endpoint-URL assertions for each new method)
- [ ] Reviewer: confirm method names match the spec ergonomics doc
- [ ] Reviewer: confirm AgentProfile field selection breadth is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)